### PR TITLE
Remove dark mode specification

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,13 +5,6 @@
     --foreground: #F3F9FF;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --background: #0a0a0a;
-        --foreground: #ededed;
-    }
-}
-
 body {
     background-color: var(--background);
     color: var(--foreground);


### PR DESCRIPTION
The only things that had dark mode specification were `--background` and `--foreground` on `:root`, leading to black bars at the top and bottom of the page when the browser had `prefers-color-scheme: dark;`. Better to remove that for now, so the styling stays consistent throughout.